### PR TITLE
chesscom/enqueue-rdkafka 0.10.15 requires ext-rdkafka ^4.0|^5.0 -> it…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.3|^8.0",
-        "ext-rdkafka": "^4.0|^5.0",
+        "ext-rdkafka": "^4.0|^5.0|^6.0",
         "queue-interop/queue-interop": "^0.8.1"
     },
     "require-dev": {


### PR DESCRIPTION
… has the wrong version installed (6.0.1)